### PR TITLE
Add pointers to OpenShift Design repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## UI Design Documentation
 
-[Website](https://kubevirt.io/web-ui-design/) // [Repository](https://github.com/kubevirt/web-ui-design)
+<mark>Note:</mark> The designs in this repository have been updated and merged into the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design).
+
+[Website](https://kubevirt.io/web-ui-design/) // <strike>Repository</strike> [New Repository](https://github.com/openshift/openshift-origin-design)
 
 This documentation shows an initial approach to allowing users to make use of KubeVirt features in the context of the [OpenShift Console](https://github.com/openshift/console).
 

--- a/ui-design/virtual-machines/clone-vm/clone-vm.md
+++ b/ui-design/virtual-machines/clone-vm/clone-vm.md
@@ -1,5 +1,7 @@
 # Clone VM
 
+<mark>Note:</mark> This design has been updated and merged into the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design).
+
 ![Offline VM in List View](img/2-0-vms.png)
 
 Cloning a VM allows the user to quickly create an identical copy of a virtual machine while powered off.

--- a/ui-design/virtual-machines/import-vm/import-vm.md
+++ b/ui-design/virtual-machines/import-vm/import-vm.md
@@ -1,5 +1,7 @@
 # Import VM
 
+<mark>Note:</mark> This design has been updated and merged into the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design).
+
 ![Provision Source Import](img/1-4-1-0-basic-provision-import.png)
 
 Virtual machines can be imported from a curated list of supported providers.

--- a/ui-design/virtual-machines/migrate-vm/migrate-vm.md
+++ b/ui-design/virtual-machines/migrate-vm/migrate-vm.md
@@ -1,5 +1,7 @@
 # Migrate VM
 
+<mark>Note:</mark> This design has been updated and merged into the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design).
+
 Clicking the action button next to any Virtual Machine in the List will present the user with the option to migrate the VM to another host.
 
 ![Selecting a VM](img/1-0-list.png)

--- a/ui-design/virtual-machines/vm-list/vm-list.md
+++ b/ui-design/virtual-machines/vm-list/vm-list.md
@@ -1,5 +1,7 @@
 # VM List view
 
+<mark>Note:</mark> This design has been updated and merged into the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design).
+
 ![List of VMs](img/0-0-main.png)
 
 The VM list contains columns for the following:


### PR DESCRIPTION
Adds a prominent note to the top of the `README` and each of the four design pages pointing visitors to the [OpenShift Design repository](https://github.com/openshift/openshift-origin-design) for updated designs.